### PR TITLE
XML Escape content in `<title>`

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -14,7 +14,7 @@ layout: nil
  
  {% for post in site.posts %}
  <entry>
-   <title>{{ post.title }}</title>
+   <title>{{ post.title | xml_escape }}</title>
    <link href="http://ericfarkas.com{{ post.url }}"/>
    <updated>{{ post.date | date_to_xmlschema }}</updated>
    <id>http://ericfarkas.com{{ post.id }}</id>


### PR DESCRIPTION
I'm back! Because now the feed doesn't validate because of the unescaped `&` in the title of the latest post.

YAY ENCODINGS.